### PR TITLE
Improve documentation. Cleanup on tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Fill in `.env` configuration variables.
    docker-compose up
    ```
 
-## swagger docs
-<http://localhost:8000/docs/#/>
+## Swagger docs
+<http://localhost:8000/docs>
 
 ## Run Production
 
@@ -48,3 +48,17 @@ Fill in `.env` configuration variables.
 ```sh
 npm test
 ```
+
+Integration tests require `jest.setup.ts` configuration to be filled in with valid operator details. Tests will run requests against `testnet` consensus services.
+
+## Authorization
+
+This project uses signed HTTP requests to authorize users. Only user who owns private key listed in `authentication` section of the targeted DID document is allowed to perform modifications. 
+There are three endpoints that in this example project have no authorization added:
+
+- `POST /did`
+- `POST /did/{did}/register`
+- `GET /did/{did}`
+
+It is up to developers to decide how these endpoints should be secured based on their use case.
+Example of how requests can be made against API please refer to `scripts/make-appnet-api-request.js` script. More details can also be found on `authentication.ts` file and `tests`.

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,6 +1,8 @@
 process.env.HEDERA_NETWORK = "testnet";
 process.env.HEDERA_OPERATOR_ID = "0.0.2..";
 process.env.HEDERA_OPERATOR_KEY = "302e..";
+/**
+ * Private key that is going to be used to register test DID documents
+ */
 process.env.DID_PRIVATE_KEY = "302e..";
-process.env.DID_PUBLIC_KEY_MULTIBASE = "z6M...";
 process.env.PORT = 8000;

--- a/src/controllers/did-document.controller.ts
+++ b/src/controllers/did-document.controller.ts
@@ -21,7 +21,9 @@ import { registerDid, resolveDid, revokeDid } from "../services";
 @Tags("Document")
 export class DidDocumentController extends Controller {
   /**
-   * Register a new DID document. User provides public key that is going to be added as a delegate key that allows user to modify created DID document later.
+   * Register a new DID document. User provides public key that is going to be added as a delegate key.
+   * That allows user to modify created DID document later. <br /><br />
+   * <em>* Based on your use case you should consider securing this endpoint. Endpoint communicates to Hedera Consensus Services.</em>
    * @summary Register a new DID Document.
    * @param body
    * @returns DidDocument
@@ -36,10 +38,11 @@ export class DidDocumentController extends Controller {
   }
 
   /**
-   * Resolve DID Document
+   * Resolve DID Document <br /><br />
+   * <em>* Based on your use case you might consider securing this endpoint. Endpoint communicates to mirror nodes to resolve DID documents.</em>
    * @summary Resolve DID Document
-   * @param did A percent-escaped DID Identifier as defined in DID specification <br /> <br />
-   * Example: did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719
+   * @param did A percent-escaped DID Identifier as defined in DID specification
+   * @example did "did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719"
    * @returns DidDocument
    */
   @Response<ValidateErrorJSON>(422, "Validation Failed")
@@ -49,10 +52,11 @@ export class DidDocumentController extends Controller {
   }
 
   /**
-   * Permanently remove DID Document from Appnet registry. In addition to that, new messages will be written to the DID topic stating that document has been removed.
+   * Permanently remove DID Document from Appnet registry.
+   * In addition to that, new messages will be written to the DID topic stating that document has been removed.
    * @summary Remove DID Document from registry
-   * @param did DID Identifier as defined in DID specification<br /> <br />
-   * Example: did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719
+   * @param did DID Identifier as defined in DID specification
+   * @example did "did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719"
    * @returns void
    */
   @Response<ValidateErrorJSON>(422, "Validation Failed")

--- a/src/controllers/did-ownership.controller.ts
+++ b/src/controllers/did-ownership.controller.ts
@@ -19,10 +19,11 @@ import { claimDidOwnership, registerDidWithAppNet } from "../services";
 @Tags("Ownership")
 export class DidOwnershipController extends Controller {
   /**
-   * Claim DID Document ownership back from the AppNet. Changes DID root key to the one provided via parameters. DID controller remains the same.
+   * Claim DID Document ownership back from the AppNet. Changes DID root key to the one provided via `privateKeyMultibase` parameter.
+   * DID controller remains the same.
    * @summary Claim DID Document ownership back from the AppNet
-   * @param did A percent-escaped DID Identifier as defined in DID specification <br /> <br />
-   * Example: did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719
+   * @param did A percent-escaped DID Identifier as defined in DID specification
+   * @example did "did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719"
    * @returns DidDocument
    */
   @Response<ValidateErrorJSON>(422, "Validation Failed")
@@ -37,10 +38,12 @@ export class DidOwnershipController extends Controller {
 
   /**
    * Register an existing DID Document with AppNet. Gives away control of the document to the AppNet component.
+   * Previous DID root (`privateKeyMultibase` parameter) key becomes a delegate key. <br /><br />
+   * <em>* Based on your use case you should consider securing this endpoint. Endpoint communicates to Hedera Consensus Services.</em>
    * @summary Register an existing DID Document with AppNet
-   * @param did A percent-escaped DID Identifier as defined in DID specification <br /> <br />
-   * Example: did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719
-   * @returns void
+   * @param did A percent-escaped DID Identifier as defined in DID specification
+   * @example did "did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719"
+   * @returns DidDocument
    */
   @Response<ValidateErrorJSON>(422, "Validation Failed")
   @Post("/{did}/register")

--- a/src/controllers/did-service.controller.ts
+++ b/src/controllers/did-service.controller.ts
@@ -25,8 +25,8 @@ export class DidServiceController extends Controller {
   /**
    * Register a new service to the DID Document
    * @summary Register a new service to the DID Document
-   * @param did Identifier as defined in DID specification <br /> <br />
-   * Example: did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719
+   * @param did Identifier as defined in DID specification
+   * @example did "did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719"
    * @param body Register service payload
    * @returns DidDocument
    */
@@ -44,10 +44,10 @@ export class DidServiceController extends Controller {
   /**
    * Update service information on the DID Document
    * @summary Update service information on the DID Document
-   * @param did Identifier as defined in DID specification <br /> <br />
-   * Example: did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719
-   * @param id Service ID string <br /> <br />
-   * Example: did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719#service-1
+   * @param did Identifier as defined in DID specification
+   * @example did "did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719"
+   * @param id Service ID string
+   * @example id "did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719#service-1"
    * @param body Update service payload
    * @returns DidDocument
    */
@@ -66,10 +66,10 @@ export class DidServiceController extends Controller {
   /**
    * Remove service information from the DID Document
    * @summary Remove service information from the DID Document
-   * @param did Identifier as defined in DID specification <br /> <br />
-   * Example: did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719
-   * @param id Service ID string <br /> <br />
-   * Example: did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719#service-1
+   * @param did Identifier as defined in DID specification
+   * @example did "did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719"
+   * @param id Service ID string
+   * @example id "did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719#service-1"
    * @returns DidDocument
    */
   @Response<ValidateErrorJSON>(422, "Validation Failed")

--- a/src/controllers/did-verification-method.controller.ts
+++ b/src/controllers/did-verification-method.controller.ts
@@ -5,7 +5,6 @@ import {
   Path,
   Post,
   Put,
-  Request,
   Response,
   Route,
   Security,
@@ -30,8 +29,8 @@ export class DidVerificationMethodController extends Controller {
   /**
    * Register a new verification method to the DID document
    * @summary Register a new verification method to the DID document
-   * @param did Identifier as defined in DID specification <br /> <br />
-   * Example: did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719
+   * @param did Identifier as defined in DID specification
+   * @example did "did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719"
    * @param body Register verification method payload
    * @returns DidDocument
    */
@@ -49,10 +48,10 @@ export class DidVerificationMethodController extends Controller {
   /**
    * Update verification method on a DID document
    * @summary Update verification method on a DID document
-   * @param did Identifier as defined in DID specification <br /> <br />
-   * Example: did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719
-   * @param id Verification Method ID string <br /> <br />
-   * Example: did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719#key-1
+   * @param did Identifier as defined in DID specification
+   * @example did "did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719"
+   * @param id Verification Method ID string
+   * @example id "did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719#key-1"
    * @param body Update verification method payload
    * @returns DidDocument
    */
@@ -70,10 +69,10 @@ export class DidVerificationMethodController extends Controller {
   /**
    * Remove verification method from the DID document
    * @summary Remove verification method from the DID document
-   * @param did Identifier as defined in DID specification <br /> <br />
-   * Example: did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719
-   * @param id Verification Method ID string <br /> <br />
-   * Example: did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719#key-1
+   * @param did Identifier as defined in DID specification
+   * @example did "did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719"
+   * @param id Verification Method ID string
+   * @example id "did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719#key-1"
    * @returns DidDocument
    */
   @Response<ValidateErrorJSON>(422, "Validation Failed")

--- a/src/controllers/did-verification-relationship.controller.ts
+++ b/src/controllers/did-verification-relationship.controller.ts
@@ -5,7 +5,6 @@ import {
   Path,
   Post,
   Put,
-  Request,
   Response,
   Route,
   Security,
@@ -31,8 +30,8 @@ export class DidVerificationRelationshipController extends Controller {
   /**
    * Register a new verification relationship to the DID document
    * @summary Register a new verification relationship to the DID document
-   * @param did Identifier as defined in DID specification <br /> <br />
-   * Example: did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719
+   * @param did Identifier as defined in DID specification
+   * @example did "did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719"
    * @param body Register verification relationship payload
    * @returns DidDocument
    */
@@ -50,11 +49,11 @@ export class DidVerificationRelationshipController extends Controller {
   /**
    * Update verification relationship on the DID document
    * @summary Update verification relationship on the DID document
-   * @param did Identifier as defined in DID specification <br /> <br />
-   * Example: did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719
+   * @param did Identifier as defined in DID specification
+   * @example did "did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719"
    * @param relationshipType String to specify which relationship type key belongs to
-   * @param id Verification Method ID string <br /> <br />
-   * Example: did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719#key-1
+   * @param id Verification Method ID string
+   * @example id "did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719#key-1"
    * @param body Update verification relationship payload
    * @returns DidDocument
    */
@@ -73,11 +72,11 @@ export class DidVerificationRelationshipController extends Controller {
   /**
    * Remove verification relationship from the DID document
    * @summary Remove verification relationship from the DID document
-   * @param did Identifier as defined in DID specification <br /> <br />
-   * Example: did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719
+   * @param did Identifier as defined in DID specification
+   * @example did "did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719"
    * @param relationshipType String to specify which relationship type key belongs to
-   * @param id Verification Method ID string <br /> <br />
-   * Example: did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719#key-1
+   * @param id Verification Method ID string
+   * @example id "did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719#key-1"
    * @returns DidDocument
    */
   @Response<ValidateErrorJSON>(422, "Validation Failed")

--- a/src/models/did-endpoint-payloads.interface.ts
+++ b/src/models/did-endpoint-payloads.interface.ts
@@ -1,3 +1,6 @@
 export interface IDidDocumentRegisterPayload {
+  /**
+   * @example "z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5"
+   */
   publicKeyMultibase: string;
 }

--- a/src/models/ownership-endpoint-payloads.interface.ts
+++ b/src/models/ownership-endpoint-payloads.interface.ts
@@ -1,7 +1,13 @@
 export interface IDidOwnershipClaimPayload {
+  /**
+   * @example "z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5"
+   */
   privateKeyMultibase: string;
 }
 
 export interface IDidOwnershipRegisterPayload {
+  /**
+   * @example "z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5"
+   */
   privateKeyMultibase: string;
 }

--- a/src/models/service-endpoint-payloads.interface.ts
+++ b/src/models/service-endpoint-payloads.interface.ts
@@ -6,6 +6,9 @@ export interface IServiceRegisterPayload {
 
 export interface IServiceUpdateBody {
   type: "LinkedDomains" | "DIDCommMessaging";
+  /**
+   * @example "https://your.service/did-comm"
+   */
   serviceEndpoint: string;
 }
 

--- a/src/models/service.interface.ts
+++ b/src/models/service.interface.ts
@@ -1,5 +1,14 @@
 export class Service {
+  /**
+   * Service ID consists of two parts: <br />
+   * 1) DID document ID service belongs to <br />
+   * 2) Unique service identifier in a format "#service-{number}"
+   * @example "did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719#service-1"
+   */
   id!: string;
   type!: "LinkedDomains" | "DIDCommMessaging";
+  /**
+   * @example "https://your.service/did-comm"
+   */
   serviceEndpoint!: string;
 }

--- a/src/models/verification-method-endpoint-payloads.interface.ts
+++ b/src/models/verification-method-endpoint-payloads.interface.ts
@@ -5,8 +5,14 @@ export interface IVerificationMethodRegisterPayload {
 }
 
 export interface IVerificationMethodUpdateBody {
+  /**
+   * @example "did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719"
+   */
   controller: string;
   type: "Ed25519VerificationKey2018";
+  /**
+   * @example "z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5"
+   */
   publicKeyMultibase: string;
 }
 

--- a/src/models/verification-method.interface.ts
+++ b/src/models/verification-method.interface.ts
@@ -1,6 +1,18 @@
 export class VerificationMethod {
+  /**
+   * Verification method ID consists of two parts: <br />
+   * 1) DID document ID verification method belongs to <br />
+   * 2) Unique verification method identifier in a format "#key-{number}"
+   * @example "did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719#key-1"
+   */
   id!: string;
+  /**
+   * @example "did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719"
+   */
   controller!: string;
   type!: "Ed25519VerificationKey2018";
+  /**
+   * @example "z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5"
+   */
   publicKeyMultibase!: string;
 }

--- a/src/models/verification-relationship-endpoint-payloads.interface.ts
+++ b/src/models/verification-relationship-endpoint-payloads.interface.ts
@@ -6,10 +6,20 @@ export type RelationshipTypeType =
   | "capabilityInvocation";
 
 export interface IVerificationRelationship {
+  /**
+   * Verification relationship ID. References a key in verification methods list.
+   * @example "did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719#key-1"
+   */
   id: string;
+  /**
+   * @example "did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719"
+   */
   controller: string;
   type: "Ed25519VerificationKey2018";
   relationshipType: RelationshipTypeType;
+  /**
+   * @example "z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5"
+   */
   publicKeyMultibase: string;
 }
 
@@ -18,8 +28,14 @@ export interface IVerificationRelationshipRegisterPayload {
 }
 
 export interface IVerificationRelationshipUpdateBody {
+  /**
+   * @example "did:hedera:testnet:z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5_0.0.30835719"
+   */
   controller: string;
   type: "Ed25519VerificationKey2018";
+  /**
+   * @example "z6Mkfza16PqnyMyxPZd7dVhs6ySUettURTztjNJ8qBKwyHg5"
+   */
   publicKeyMultibase: string;
 }
 

--- a/test/integration/did-document.test.ts
+++ b/test/integration/did-document.test.ts
@@ -1,13 +1,15 @@
 import { PrivateKey } from "@hashgraph/sdk";
 import supertest from "supertest";
 import { app } from "../../src/server";
-import { generateAuthHeaders } from "../utils";
+import { generateAuthHeaders, getPublicKeyMultibase } from "../utils";
 import { setupBeforeAndAfter } from "./setup";
 
-const DID_PUBLIC_KEY_MULTIBASE = process.env.DID_PUBLIC_KEY_MULTIBASE || "";
-const DID_PRIVATE_KEY = process.env.DID_PRIVATE_KEY || "";
-
 describe("DID Document", () => {
+  const DID_PRIVATE_KEY = PrivateKey.fromString(
+    process.env.DID_PRIVATE_KEY || ""
+  );
+  const DID_PUBLIC_KEY_MULTIBASE = getPublicKeyMultibase(DID_PRIVATE_KEY);
+
   //setup in memory mongodb and mock mongoose db connection
   setupBeforeAndAfter();
   describe("resolve DID Document", () => {
@@ -178,8 +180,6 @@ describe("DID Document", () => {
           newDIDDocument.body.verificationMethod[1].publicKeyMultibase
         ).toEqual(DID_PUBLIC_KEY_MULTIBASE);
 
-        const signer = PrivateKey.fromString(DID_PRIVATE_KEY);
-
         const requestOptions = {
           json: true,
           url: `http://localhost:8000/did/${newDIDDocument.body.id}`,
@@ -189,7 +189,7 @@ describe("DID Document", () => {
 
         const authHeaders = await generateAuthHeaders(
           requestOptions,
-          signer,
+          DID_PRIVATE_KEY,
           newDIDDocument.body.verificationMethod[1].id
         );
 

--- a/test/integration/did-ownership.test.ts
+++ b/test/integration/did-ownership.test.ts
@@ -1,17 +1,16 @@
-import { HcsDid } from "@hashgraph/did-sdk-js/dist/identity/hcs/did/hcs-did";
-import { Hashing } from "@hashgraph/did-sdk-js/dist/utils/hashing";
+import { Hashing, HcsDid } from "@hashgraph/did-sdk-js";
 import { PrivateKey } from "@hashgraph/sdk";
 import supertest from "supertest";
 import { app } from "../../src/server";
-import { generateAuthHeaders } from "../utils";
-import { setupBeforeAndAfter } from "./setup";
 import { client } from "../../src/services";
-
-const DID_PUBLIC_KEY_MULTIBASE = process.env.DID_PUBLIC_KEY_MULTIBASE || "";
-const DID_PRIVATE_KEY = process.env.DID_PRIVATE_KEY || "";
+import { generateAuthHeaders, getPublicKeyMultibase } from "../utils";
+import { setupBeforeAndAfter } from "./setup";
 
 describe("DID Service", () => {
-  const signer = PrivateKey.fromString(DID_PRIVATE_KEY);
+  const DID_PRIVATE_KEY = PrivateKey.fromString(
+    process.env.DID_PRIVATE_KEY || ""
+  );
+  const DID_PUBLIC_KEY_MULTIBASE = getPublicKeyMultibase(DID_PRIVATE_KEY);
 
   //setup in memory mongodb and mock mongoose db connection
   setupBeforeAndAfter();
@@ -30,9 +29,7 @@ describe("DID Service", () => {
           registeredDidDocument.body.verificationMethod[1].publicKeyMultibase
         ).toEqual(DID_PUBLIC_KEY_MULTIBASE);
 
-        const pkMultibase = Hashing.multibase.encode(
-          PrivateKey.fromString(DID_PRIVATE_KEY).toBytes()
-        );
+        const pkMultibase = Hashing.multibase.encode(DID_PRIVATE_KEY.toBytes());
         const body = {
           privateKeyMultibase: pkMultibase,
         };
@@ -47,7 +44,7 @@ describe("DID Service", () => {
 
         const authHeaders = await generateAuthHeaders(
           requestOptions,
-          signer,
+          DID_PRIVATE_KEY,
           registeredDidDocument.body.verificationMethod[1].id
         );
 

--- a/test/integration/did-service.test.ts
+++ b/test/integration/did-service.test.ts
@@ -1,18 +1,19 @@
 import { PrivateKey } from "@hashgraph/sdk";
-import supertest from "supertest";
+import supertest, { Response } from "supertest";
 import { app } from "../../src/server";
-import { generateAuthHeaders } from "../utils";
+import { generateAuthHeaders, getPublicKeyMultibase } from "../utils";
 import { setupBeforeAndAfter } from "./setup";
 
-const DID_PUBLIC_KEY_MULTIBASE = process.env.DID_PUBLIC_KEY_MULTIBASE || "";
-const DID_PRIVATE_KEY = process.env.DID_PRIVATE_KEY || "";
 describe("DID Service", () => {
-  let registeredDidDocument: any = null;
+  const DID_PRIVATE_KEY = PrivateKey.fromString(
+    process.env.DID_PRIVATE_KEY || ""
+  );
+  const DID_PUBLIC_KEY_MULTIBASE = getPublicKeyMultibase(DID_PRIVATE_KEY);
 
   const serviceIdentifier =
     "did:hedera:testnet:z6MkubW6fwkWSA97RbKs17MtLgWGHBtShQygUc5SeHueFCaG_0.0.29656231#service-1";
 
-  const signer = PrivateKey.fromString(DID_PRIVATE_KEY);
+  let registeredDidDocument: Response;
 
   //setup in memory mongodb and mock mongoose db connection
   setupBeforeAndAfter();
@@ -50,8 +51,7 @@ describe("DID Service", () => {
 
         const authHeaders = await generateAuthHeaders(
           requestOptions,
-          signer,
-
+          DID_PRIVATE_KEY,
           registeredDidDocument.body.verificationMethod[1].id
         );
 
@@ -91,7 +91,7 @@ describe("DID Service", () => {
 
         const authHeaders = await generateAuthHeaders(
           requestOptions,
-          signer,
+          DID_PRIVATE_KEY,
           registeredDidDocument.body.verificationMethod[1].id
         );
 
@@ -129,7 +129,7 @@ describe("DID Service", () => {
 
         const authHeaders = await generateAuthHeaders(
           requestOptions,
-          signer,
+          DID_PRIVATE_KEY,
           registeredDidDocument.body.verificationMethod[1].id
         );
 

--- a/test/integration/did-verification-method.test.ts
+++ b/test/integration/did-verification-method.test.ts
@@ -1,21 +1,21 @@
 import { PrivateKey } from "@hashgraph/sdk";
-import supertest from "supertest";
+import supertest, { Response } from "supertest";
 import { app } from "../../src/server";
-import { generateAuthHeaders } from "../utils";
+import { generateAuthHeaders, getPublicKeyMultibase } from "../utils";
 import { setupBeforeAndAfter } from "./setup";
 
-const DID_PUBLIC_KEY_MULTIBASE = process.env.DID_PUBLIC_KEY_MULTIBASE || "";
-const DID_PRIVATE_KEY = process.env.DID_PRIVATE_KEY || "";
 describe("DID Verification Method", () => {
-  let registeredDidDocument: any = null;
+  const DID_PRIVATE_KEY = PrivateKey.fromString(
+    process.env.DID_PRIVATE_KEY || ""
+  );
+  const DID_PUBLIC_KEY_MULTIBASE = getPublicKeyMultibase(DID_PRIVATE_KEY);
 
   const verificationMethodIdentifier =
     "did:hedera:testnet:z6MkubW6fwkWSA97RbKs17MtLgWGHBtShQygUc5SeHueFCaG_0.0.29656231#key-1";
-
   const verificationMethodPublicKey =
     "z6Mkkcn1EDXc5vzpmvnQeCKpEswyrnQG7qq59k92gFRm1EGk";
 
-  const signer = PrivateKey.fromString(DID_PRIVATE_KEY);
+  let registeredDidDocument: Response;
 
   //setup in memory mongodb and mock mongoose db connection
   setupBeforeAndAfter();
@@ -54,7 +54,7 @@ describe("DID Verification Method", () => {
 
         const authHeaders = await generateAuthHeaders(
           requestOptions,
-          signer,
+          DID_PRIVATE_KEY,
           registeredDidDocument.body.verificationMethod[1].id
         );
 
@@ -102,7 +102,7 @@ describe("DID Verification Method", () => {
 
         const authHeaders = await generateAuthHeaders(
           requestOptions,
-          signer,
+          DID_PRIVATE_KEY,
           registeredDidDocument.body.verificationMethod[1].id
         );
 
@@ -144,7 +144,7 @@ describe("DID Verification Method", () => {
 
         const authHeaders = await generateAuthHeaders(
           requestOptions,
-          signer,
+          DID_PRIVATE_KEY,
           registeredDidDocument.body.verificationMethod[1].id
         );
 

--- a/test/integration/did-verification-relationship.test.ts
+++ b/test/integration/did-verification-relationship.test.ts
@@ -1,23 +1,22 @@
 import { PrivateKey } from "@hashgraph/sdk";
-import supertest from "supertest";
+import supertest, { Response } from "supertest";
 import { app } from "../../src/server";
-import { generateAuthHeaders } from "../utils";
+import { generateAuthHeaders, getPublicKeyMultibase } from "../utils";
 import { setupBeforeAndAfter } from "./setup";
 
-const DID_PUBLIC_KEY_MULTIBASE = process.env.DID_PUBLIC_KEY_MULTIBASE || "";
-const DID_PRIVATE_KEY = process.env.DID_PRIVATE_KEY || "";
 describe("DID Verification Relationships", () => {
-  let registeredDidDocument: any = null;
+  const DID_PRIVATE_KEY = PrivateKey.fromString(
+    process.env.DID_PRIVATE_KEY || ""
+  );
+  const DID_PUBLIC_KEY_MULTIBASE = getPublicKeyMultibase(DID_PRIVATE_KEY);
 
   const verificationRelationshipIdentifier =
     "did:hedera:testnet:z6MkubW6fwkWSA97RbKs17MtLgWGHBtShQygUc5SeHueFCaG_0.0.29656231#key-1";
-
   const verificationRelationshipPublicKey =
     "z6Mkkcn1EDXc5vzpmvnQeCKpEswyrnQG7qq59k92gFRm1EGk";
-
-  const signer = PrivateKey.fromString(DID_PRIVATE_KEY);
-
   const verificationRelationshipType = "authentication";
+
+  let registeredDidDocument: Response;
 
   //setup in memory mongodb and mock mongoose db connection
   setupBeforeAndAfter();
@@ -57,8 +56,7 @@ describe("DID Verification Relationships", () => {
 
         const authHeaders = await generateAuthHeaders(
           requestOptions,
-          signer,
-
+          DID_PRIVATE_KEY,
           registeredDidDocument.body.verificationMethod[1].id
         );
 
@@ -113,7 +111,7 @@ describe("DID Verification Relationships", () => {
 
         const authHeaders = await generateAuthHeaders(
           requestOptions,
-          signer,
+          DID_PRIVATE_KEY,
           registeredDidDocument.body.verificationMethod[1].id
         );
 
@@ -156,8 +154,7 @@ describe("DID Verification Relationships", () => {
 
         const authHeaders = await generateAuthHeaders(
           requestOptions,
-          signer,
-
+          DID_PRIVATE_KEY,
           registeredDidDocument.body.verificationMethod[1].id
         );
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,3 +1,4 @@
+import { Hashing } from "@hashgraph/did-sdk-js";
 import { PrivateKey } from "@hashgraph/sdk";
 import { createHeaderValue } from "../src/utils";
 const httpSignature = require("@digitalbazaar/http-signature-header");
@@ -56,4 +57,8 @@ export const generateAuthHeaders = async (
     ...headers,
     Authorization: authorization,
   };
+};
+
+export const getPublicKeyMultibase = (privateKey: PrivateKey) => {
+  return Hashing.multibase.encode(privateKey.publicKey.toBytes());
 };

--- a/tsoa.json
+++ b/tsoa.json
@@ -7,7 +7,7 @@
     "specVersion": 3,
     "title": "Hedera Appnet API",
     "version": "1.0.0",
-    "description": "This is a hedera appnet API application",
+    "description": "Hedera Appnet API",
     "license": "MIT",
     "contact": {
       "name": "Meeco",


### PR DESCRIPTION
- Add some more documentation. 
- Provide examples for the parameters. 
- Describe authorization logic.
- `process.env.DID_PUBLIC_KEY_MULTIBASE` removed from test configuration since it can be generated on fly from the private key.
